### PR TITLE
Infer HTTP method if not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ cargo install ht
 ## Usage
 ```
 ht 0.2.0
-
 USAGE:
-    ht [FLAGS] [OPTIONS] <METHOD> <URL> [REQUEST_ITEM]...
+    ht.exe [FLAGS] [OPTIONS] <[METHOD] URL> [REQUEST_ITEM]...
 
 FLAGS:
         --offline         Construct HTTP requests without sending them anywhere
@@ -26,6 +25,7 @@ FLAGS:
     -m, --multipart       Similar to --form, but always sends a multipart/form-data request (i.e., even without files)
     -I, --ignore-stdin    Do not attempt to read stdin
     -d, --download
+    -c, --continue        Resume an interrupted download
     -v, --verbose         Print the whole request as well as the response
     -q, --quiet           Do not print to stdout or stderr
     -h, --help            Prints help information
@@ -41,8 +41,7 @@ OPTIONS:
         --default-scheme <default-scheme>    The default scheme to use if not specified in the URL
 
 ARGS:
-    <METHOD>             The HTTP method to be used for the request [possible values: GET, POST, PUT, PATCH, DELETE]
-    <URL>
+    <[METHOD] URL>       The request URL, preceded by an optional HTTP method
     <REQUEST_ITEM>...    Optional key-value pairs to be included in the request
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,27 +71,58 @@ pub struct Cli {
     #[structopt(long = "default-scheme")]
     pub default_scheme: Option<String>,
 
-    /// The HTTP method to be used for the request.
-    #[structopt(name = "METHOD", possible_values = &Method::variants(), case_insensitive = true)]
-    pub method: Method,
-
-    #[structopt(name = "URL")]
-    pub url: String,
+    #[structopt(name = "[METHOD] URL", parse(try_from_str = parse_method_url))]
+    pub method_url: (Option<Method>, String),
 
     /// Optional key-value pairs to be included in the request.
     #[structopt(name = "REQUEST_ITEM")]
     pub request_items: Vec<RequestItem>,
 }
 
-// TODO: add remaining methods
-arg_enum! {
-    #[derive(Debug, Clone, Copy)]
-    pub enum Method {
-        GET,
-        POST,
-        PUT,
-        PATCH,
-        DELETE
+impl Cli {
+    pub fn from_args() -> Self {
+        let mut args = vec![];
+        let mut method = None;
+        for arg in std::env::args() {
+            if arg.parse::<Method>().is_ok() {
+                method = Some(arg)
+            } else if method.is_some() {
+                args.push(format!("{} {}", method.unwrap(), arg));
+                method = None;
+            } else {
+                args.push(arg);
+            }
+        }
+
+        Cli::from_iter(args)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Method {
+    GET,
+    POST,
+    PUT,
+    PATCH,
+    DELETE
+}
+
+impl FromStr for Method {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Method> {
+        match s.to_ascii_uppercase().as_str() {
+            "GET" => Ok(Method::GET),
+            "POST" => Ok(Method::POST),
+            "PUT" => Ok(Method::PUT),
+            "PATCH" => Ok(Method::PATCH),
+            "DELETE" => Ok(Method::DELETE),
+            method => {
+                return Err(Error::with_description(
+                    &format!("unknown http method {}", method),
+                    ErrorKind::InvalidValue,
+                ))
+            }
+        }
     }
 }
 
@@ -104,6 +135,15 @@ impl From<Method> for reqwest::Method {
             Method::PATCH => reqwest::Method::PATCH,
             Method::DELETE => reqwest::Method::DELETE,
         }
+    }
+}
+
+fn parse_method_url(s: &str) -> Result<(Option<Method>, String)> {
+    let parts = s.split_whitespace().collect::<Vec<_>>();
+    if parts.len() == 1 {
+        Ok((None, parts[0].to_string()))
+    } else {
+        Ok((Some(parts[0].parse()?), parts[1].to_string()))
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,7 +106,7 @@ pub enum Method {
     POST,
     PUT,
     PATCH,
-    DELETE
+    DELETE,
 }
 
 impl FromStr for Method {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,7 @@ impl Cli {
     pub fn from_args() -> Self {
         let mut args = vec![];
         let mut method = None;
+        // merge method and url in the env args
         for arg in std::env::args() {
             if arg.parse::<Method>().is_ok() {
                 method = Some(arg)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,7 +84,7 @@ impl Cli {
     pub fn from_args() -> Self {
         let mut args = vec![];
         let mut method = None;
-        // merge method and url in the env args
+        // Merge `method` and `url` entries from std::env::args()
         for arg in std::env::args() {
             if arg.parse::<Method>().is_ok() {
                 method = Some(arg)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,6 +71,7 @@ pub struct Cli {
     #[structopt(long = "default-scheme")]
     pub default_scheme: Option<String>,
 
+    /// The request URL, preceded by an optional HTTP method.
     #[structopt(name = "[METHOD] URL", parse(try_from_str = parse_method_url))]
     pub method_url: (Option<Method>, String),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,13 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let (method, url) = args.method_url;
     let url = Url::new(url, args.default_scheme);
     let host = url.host().unwrap();
-    let method = method.unwrap_or(if body.is_none() { Method::GET } else { Method::POST }).into();
+    let method = method
+        .unwrap_or(if body.is_none() {
+            Method::GET
+        } else {
+            Method::POST
+        })
+        .into();
     let auth = Auth::new(args.auth, args.auth_type, &host);
 
     let client = Client::new();
@@ -98,19 +104,17 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         Some(_) => Buffer::Terminal(Box::new(std::io::stdout())),
         None => Buffer::Terminal(Box::new(std::io::stdout())),
     };
-    let print = args.print.unwrap_or(
-        if args.verbose {
-            Print::new(true, true, true, true)
-        } else if args.quiet {
-            Print::new(false, false, false, false)
-        } else if args.offline {
-            Print::new(true, true, false, false)
-        } else if !matches!(&buffer, Buffer::Terminal(_)) {
-            Print::new(false, false, false, true)
-        } else {
-            Print::new(false, false, true, true)
-        }
-    );
+    let print = args.print.unwrap_or(if args.verbose {
+        Print::new(true, true, true, true)
+    } else if args.quiet {
+        Print::new(false, false, false, false)
+    } else if args.offline {
+        Print::new(true, true, false, false)
+    } else if !matches!(&buffer, Buffer::Terminal(_)) {
+        Print::new(false, false, false, true)
+    } else {
+        Print::new(false, false, true, true)
+    });
     let mut printer = Printer::new(args.pretty, args.theme, buffer);
 
     if print.request_headers {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use reqwest::header::{
     HeaderValue, ACCEPT, ACCEPT_ENCODING, CONNECTION, CONTENT_TYPE, HOST, RANGE,
 };
 use reqwest::{Client, StatusCode};
-use structopt::StructOpt;
 #[macro_use]
 extern crate lazy_static;
 
@@ -16,7 +15,7 @@ mod url;
 mod utils;
 
 use auth::Auth;
-use cli::{AuthType, Cli, Pretty, Print, RequestItem, Theme};
+use cli::{AuthType, Cli, Method, Pretty, Print, RequestItem, Theme};
 use download::{download_file, get_file_size};
 use printer::{Buffer, Printer};
 use request_items::{Body, RequestItems};
@@ -28,11 +27,6 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let args = Cli::from_args();
 
     let request_items = RequestItems::new(args.request_items);
-
-    let url = Url::new(args.url, args.default_scheme);
-    let host = url.host().unwrap();
-    let method = args.method.into();
-    let auth = Auth::new(args.auth, args.auth_type, &host);
     let query = request_items.query();
     let (headers, headers_to_unset) = request_items.headers();
     let body = match (
@@ -47,6 +41,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         (Some(body), None) | (None, Some(body)) => Some(body),
         (None, None) => None,
     };
+
+    let (method, url) = args.method_url;
+    let url = Url::new(url, args.default_scheme);
+    let host = url.host().unwrap();
+    let method = method.unwrap_or(if body.is_none() { Method::GET } else { Method::POST }).into();
+    let auth = Auth::new(args.auth, args.auth_type, &host);
 
     let client = Client::new();
     let request = {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -23,7 +23,7 @@ const BINARY_SUPPRESSOR: &str = concat!(
 pub enum Buffer {
     File(Box<dyn IoWrite>),
     Redirect(Box<dyn IoWrite>),
-    Terminal(Box<dyn IoWrite>)
+    Terminal(Box<dyn IoWrite>),
 }
 
 pub struct Printer {
@@ -36,17 +36,15 @@ pub struct Printer {
 
 impl Printer {
     pub fn new(pretty: Option<Pretty>, theme: Option<Theme>, buffer: Buffer) -> Printer {
-        let pretty = pretty.unwrap_or(
-            match buffer {
-                Buffer::File(_) | Buffer::Redirect(_) => Pretty::None,
-                Buffer::Terminal(_) => Pretty::All
-            }
-        );
+        let pretty = pretty.unwrap_or(match buffer {
+            Buffer::File(_) | Buffer::Redirect(_) => Pretty::None,
+            Buffer::Terminal(_) => Pretty::All,
+        });
         let theme = theme.unwrap_or(Theme::Auto);
         let buffer = match buffer {
             Buffer::File(buffer) => buffer,
             Buffer::Redirect(buffer) => buffer,
-            Buffer::Terminal(buffer) => buffer
+            Buffer::Terminal(buffer) => buffer,
         };
 
         match pretty {


### PR DESCRIPTION
This is a hacky and temporary solution to issue #2. Here are the drawbacks I can think of so far:

1. The `Method` and the `URL` are now treated as one in the manpages
#### Before
```
USAGE:
    ht [FLAGS] [OPTIONS] <METHOD> <URL> [REQUEST_ITEM]...
ARGS:
    <METHOD>             The HTTP method to be used for the request [possible values: GET, POST, PUT, PATCH, DELETE]
    <URL>
    <REQUEST_ITEM>...    Optional key-value pairs to be included in the request
```

#### After
```
USAGE:
    ht.exe [FLAGS] [OPTIONS] <[METHOD] URL> [REQUEST_ITEM]...

ARGS:
    <[METHOD] URL>
    <REQUEST_ITEM>...    Optional key-value pairs to be included in the request
```
2. It is not possible to have a flag between the `Method` and the `URL`. For example, the following will not be a valid usage anymore
```
ht post --offline httpbin.org/post name=ahmed
```
Instead, any flags should be before the `Method` or after the `URL`
```
ht --offline post httpbin.org/json name=ahmed
ht post httpbin.org/json --offline name=ahmed
```

Closes #2
