### PR TITLE
Render white text as the default foreground color

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -95,7 +95,10 @@ pub fn colorize<'a>(
             let mut s: String = String::new();
             let highlights = h.highlight(line, &PS);
             for (style, component) in highlights {
-                let mut color = Style::from(to_ansi_color(style.foreground));
+                let mut color = Style {
+                    foreground: to_ansi_color(style.foreground),
+                    ..Style::default()
+                };
                 if style.font_style.contains(FontStyle::UNDERLINE) {
                     color = color.underline();
                 }
@@ -107,25 +110,28 @@ pub fn colorize<'a>(
 }
 
 // https://github.com/sharkdp/bat/blob/3a85fd767bd1f03debd0a60ac5bc08548f95bc9d/src/terminal.rs
-fn to_ansi_color(color: syntect::highlighting::Color) -> ansi_term::Color {
+fn to_ansi_color(color: syntect::highlighting::Color) -> Option<ansi_term::Color> {
     if color.a == 0 {
         // Themes can specify one of the user-configurable terminal colors by
         // encoding them as #RRGGBBAA with AA set to 00 (transparent) and RR set
         // to the 8-bit color palette number. The built-in themes ansi-light,
         // ansi-dark, base16, and base16-256 use this.
         match color.r {
-            // For the first 8 colors, use the Color enum to produce ANSI escape
+            // For the first 7 colors, use the Color enum to produce ANSI escape
             // sequences using codes 30-37 (foreground) and 40-47 (background).
             // For example, red foreground is \x1b[31m. This works on terminals
             // without 256-color support.
-            0x00 => Color::Black,
-            0x01 => Color::Red,
-            0x02 => Color::Green,
-            0x03 => Color::Yellow,
-            0x04 => Color::Blue,
-            0x05 => Color::Purple,
-            0x06 => Color::Cyan,
-            0x07 => Color::White,
+            0x00 => Some(Color::Black),
+            0x01 => Some(Color::Red),
+            0x02 => Some(Color::Green),
+            0x03 => Some(Color::Yellow),
+            0x04 => Some(Color::Blue),
+            0x05 => Some(Color::Purple),
+            0x06 => Some(Color::Cyan),
+            // The 8th color is white. Themes use it as the default foreground
+            // color, but that looks wrong on terminals with a light background.
+            // So keep that text uncolored instead.
+            0x07 => None,
             // For all other colors, use Fixed to produce escape sequences using
             // codes 38;5 (foreground) and 48;5 (background). For example,
             // bright red foreground is \x1b[38;5;9m. This only works on
@@ -134,10 +140,10 @@ fn to_ansi_color(color: syntect::highlighting::Color) -> ansi_term::Color {
             // TODO: When ansi_term adds support for bright variants using codes
             // 90-97 (foreground) and 100-107 (background), we should use those
             // for values 0x08 to 0x0f and only use Fixed for 0x10 to 0xff.
-            n => Fixed(n),
+            n => Some(Fixed(n)),
         }
     } else {
-        RGB(color.r, color.g, color.b)
+        Some(RGB(color.r, color.g, color.b))
     }
 }
 


### PR DESCRIPTION
The default theme is unfortunately hard to read with a light background:
![image](https://user-images.githubusercontent.com/15526524/107119006-0a704100-6885-11eb-8a7a-ee4c44f5b416.png)
Treating white text as uncolored fixes that:
![image](https://user-images.githubusercontent.com/15526524/107119123-c03b8f80-6885-11eb-9c21-fe8c9e264c1c.png)
That also seems to match HTTPie. 