### PR TITLE
Init parsing regex for RequestItem only once

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -293,16 +293,22 @@ pub enum RequestItem {
 impl FromStr for RequestItem {
     type Err = Error;
     fn from_str(request_item: &str) -> Result<RequestItem> {
-        let re1 = Regex::new(r"^(.+?)@(.+?);type=(.+?)$").unwrap();
-        let re2 = Regex::new(r"^(.+?)(==|:=|=|@|:)(.+)$").unwrap();
-        let re3 = Regex::new(r"^(.+?)(:|;)$").unwrap();
+        lazy_static::lazy_static! {
+            static ref RE1: Regex = Regex::new(r"^(.+?)@(.+?);type=(.+?)$").unwrap();
+        }
+        lazy_static::lazy_static! {
+            static ref RE2: Regex = Regex::new(r"^(.+?)(==|:=|=|@|:)(.+)$").unwrap();
+        }
+        lazy_static::lazy_static! {
+            static ref RE3: Regex = Regex::new(r"^(.+?)(:|;)$").unwrap();
+        }
 
-        if let Some(caps) = re1.captures(request_item) {
+        if let Some(caps) = RE1.captures(request_item) {
             let key = caps[1].to_string();
             let value = caps[2].to_string();
             let file_type = caps[3].to_string();
             Ok(RequestItem::FormFile(key, value, Some(file_type)))
-        } else if let Some(caps) = re2.captures(request_item) {
+        } else if let Some(caps) = RE2.captures(request_item) {
             let key = caps[1].to_string();
             let value = caps[3].to_string();
             match &caps[2] {
@@ -316,7 +322,7 @@ impl FromStr for RequestItem {
                 "@" => Ok(RequestItem::FormFile(key, value, None)),
                 _ => unreachable!(),
             }
-        } else if let Some(caps) = re3.captures(request_item) {
+        } else if let Some(caps) = RE3.captures(request_item) {
             let key = caps[1].to_string();
             match &caps[2] {
                 ":" => Ok(RequestItem::HttpHeaderToUnset(key)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,6 @@ use reqwest::header::{
 };
 use reqwest::{Client, StatusCode};
 
-#[macro_use]
-extern crate lazy_static;
-
-#[cfg(test)]
-#[macro_use]
-extern crate assert_matches;
-
 mod auth;
 mod buffer;
 mod cli;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -204,6 +204,7 @@ impl Printer {
 mod test {
     use super::*;
     use crate::{cli::Cli, vec_of_strings};
+    use assert_matches::assert_matches;
 
     fn run_cmd(args: impl IntoIterator<Item = String>, is_stdout_tty: bool) -> Printer {
         let args = Cli::from_iter(args);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -74,7 +74,7 @@ pub fn colorize<'a>(
     syntax: &str,
     theme: &Theme,
 ) -> impl Iterator<Item = String> + 'a {
-    lazy_static! {
+    lazy_static::lazy_static! {
         static ref TS: ThemeSet = ThemeSet::from(from_binary(include_bytes!(concat!(
             env!("OUT_DIR"),
             "/themepack.themedump"


### PR DESCRIPTION
I thought maybe you might appreciate that. Perhaps also investigate replacing `lazy_static` with the safer `once_cell::sync::Lazy` ?

And BTW in Rust 2018 edition you don't need :

```rust
#[macro_use]
extern crate name;
```