### PR TITLE
Use write_all instead of write to ensure everything is written

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -103,7 +103,7 @@ pub async fn download_file(
 
     let mut downloaded = 0;
     while let Some(chunk) = response.chunk().await.unwrap() {
-        buffer.write(&chunk).unwrap();
+        buffer.write_all(&chunk).unwrap();
         downloaded += chunk.len() as u64;
         if let Some(pb) = &pb {
             pb.set_position(downloaded);


### PR DESCRIPTION
`write` doesn't always write everything, but `write_all` makes sure you don't drop any output.

Found by `cargo clippy`: https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount

Clippy also gives some warnings about small inefficiencies and code that could be shorter, but this was the only functional thing.