### PR TITLE
Do not explicitly add `Host` header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 use atty::Stream;
-use reqwest::header::{
-    HeaderValue, ACCEPT, ACCEPT_ENCODING, CONNECTION, CONTENT_TYPE, HOST, RANGE,
-};
+use reqwest::header::{HeaderValue, ACCEPT, ACCEPT_ENCODING, CONNECTION, CONTENT_TYPE, RANGE};
 use reqwest::{Client, StatusCode};
 
 mod auth;
@@ -58,8 +56,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut request_builder = client
             .request(method, url.0)
             .header(ACCEPT_ENCODING, HeaderValue::from_static("gzip, deflate"))
-            .header(CONNECTION, HeaderValue::from_static("keep-alive"))
-            .header(HOST, HeaderValue::from_str(&host)?);
+            .header(CONNECTION, HeaderValue::from_static("keep-alive"));
 
         request_builder = match body {
             Some(Body::Form(body)) => request_builder


### PR DESCRIPTION
HTTP/2 forbids it, and it's added anyway otherwise.

`Connection` is technically not allowed either, but it doesn't seem to cause trouble in practice.

Resolves #13, #20.

(Thank you for this tool, by the way! I had been looking for a snappier alternative to HTTPie and this is perfect.)