### PR TITLE
README - update macOS instructions to use homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Yet another [HTTPie](https://httpie.io/) clone in Rust.
 
 ### On macOS via Homebrew
 ```
-brew tap ducaale/ht-rs
-brew install ht-rs
+brew install ht-rust
 ```
 
 ### On Arch Linux via AUR


### PR DESCRIPTION
`ht` is now included in [Homebrew core](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ht-rust.rb) so the installation instructions can be updated to point there instead of needing a separate tap.