### PR TITLE
Add User-Agent header

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,9 +2,15 @@ use assert_cmd::prelude::*;
 use indoc::indoc;
 use std::process::Command;
 
+fn get_command() -> Command {
+    let mut cmd = Command::cargo_bin("ht").expect("binary should be present");
+    cmd.env("HT_TEST_MODE", "1");
+    cmd
+}
+
 #[test]
 fn basic_post() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("ht")?;
+    let mut cmd = get_command();
     cmd.arg("-v")
         .arg("--offline")
         .arg("--ignore-stdin")
@@ -21,6 +27,7 @@ fn basic_post() -> Result<(), Box<dyn std::error::Error>> {
         content-length: 14
         content-type: application/json
         host: httpbin.org
+        user-agent: ht/0.0.0 (test mode)
 
         {
             "name": "ali"
@@ -33,7 +40,7 @@ fn basic_post() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn basic_get() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("ht")?;
+    let mut cmd = get_command();
     cmd.arg("-v")
         .arg("--offline")
         .arg("--ignore-stdin")
@@ -47,6 +54,7 @@ fn basic_get() -> Result<(), Box<dyn std::error::Error>> {
         accept-encoding: gzip, deflate
         connection: keep-alive
         host: httpbin.org
+        user-agent: ht/0.0.0 (test mode)
 
     "#});
 
@@ -55,7 +63,7 @@ fn basic_get() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn basic_head() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("ht")?;
+    let mut cmd = get_command();
     cmd.arg("-v")
         .arg("--offline")
         .arg("--ignore-stdin")
@@ -69,6 +77,7 @@ fn basic_head() -> Result<(), Box<dyn std::error::Error>> {
         accept-encoding: gzip, deflate
         connection: keep-alive
         host: httpbin.org
+        user-agent: ht/0.0.0 (test mode)
 
     "#});
 


### PR DESCRIPTION
This also adds a rudimentary way to detect an integration test. If that's useful for other things it could be extracted to a function (or lazy static) in `utils`.