### PR TITLE
Bubble errors up to main() instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+
+[[package]]
 name = "assert_cmd"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +430,7 @@ name = "ht"
 version = "0.5.0"
 dependencies = [
  "ansi_term 0.12.1",
+ "anyhow",
  "assert_cmd",
  "assert_matches",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 
 [dependencies]
 ansi_term = "0.12"
+anyhow = "1.0.38"
 assert_matches = "1.4.0"
 atty = "0.2"
 jsonxf = "1.0"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use regex::Regex;
 
 use crate::AuthType;
@@ -9,19 +10,23 @@ pub enum Auth {
 }
 
 impl Auth {
-    pub fn new(auth: Option<String>, auth_type: Option<AuthType>, host: &str) -> Option<Auth> {
+    pub fn new(
+        auth: Option<String>,
+        auth_type: Option<AuthType>,
+        host: &str,
+    ) -> Result<Option<Auth>> {
         let auth_type = auth_type.unwrap_or(AuthType::Basic);
         let auth = match auth {
             Some(auth) if !auth.is_empty() => auth,
-            _ => {
-                return None;
-            }
+            _ => return Ok(None),
         };
 
-        match auth_type {
+        Ok(match auth_type {
             AuthType::Basic => {
-                let re = Regex::new(r"^(.+?):(.*)$").unwrap();
-                if let Some(cap) = re.captures(&auth) {
+                lazy_static::lazy_static! {
+                    static ref RE: Regex = Regex::new(r"^(.+?):(.*)$").unwrap();
+                }
+                if let Some(cap) = RE.captures(&auth) {
                     let username = cap[1].to_string();
                     let password = if !cap[2].is_empty() {
                         Some(cap[2].to_string())
@@ -32,11 +37,11 @@ impl Auth {
                 } else {
                     let username = auth;
                     let prompt = format!("http: password for {}@{}: ", username, host);
-                    let password = rpassword::read_password_from_tty(Some(&prompt)).unwrap();
+                    let password = rpassword::read_password_from_tty(Some(&prompt))?;
                     Some(Auth::Basic(username, Some(password)))
                 }
             }
             AuthType::Bearer => Some(Auth::Bearer(auth)),
-        }
+        })
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,8 +106,8 @@ impl Cli {
         for arg in iter {
             if arg.parse::<Method>().is_ok() {
                 method = Some(arg)
-            } else if method.is_some() {
-                args.push(format!("{} {}", method.unwrap(), arg));
+            } else if let Some(method_value) = method {
+                args.push(format!("{} {}", method_value, arg));
                 method = None;
             } else {
                 args.push(arg);
@@ -140,12 +140,10 @@ impl FromStr for Method {
             "PATCH" => Ok(Method::PATCH),
             "DELETE" => Ok(Method::DELETE),
             "OPTIONS" => Ok(Method::OPTIONS),
-            method => {
-                return Err(Error::with_description(
-                    &format!("unknown http method {}", method),
-                    ErrorKind::InvalidValue,
-                ))
-            }
+            method => Err(Error::with_description(
+                &format!("unknown http method {}", method),
+                ErrorKind::InvalidValue,
+            )),
         }
     }
 }
@@ -331,7 +329,12 @@ impl FromStr for RequestItem {
                 "=" => Ok(RequestItem::DataField(key, value)),
                 ":=" => Ok(RequestItem::JSONField(
                     key,
-                    serde_json::from_str(&value).unwrap(),
+                    serde_json::from_str(&value).map_err(|err| {
+                        Error::with_description(
+                            &format!("{:?}: {}", request_item, err),
+                            ErrorKind::InvalidValue,
+                        )
+                    })?,
                 )),
                 "@" => Ok(RequestItem::FormFile(key, value, None)),
                 _ => unreachable!(),

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,6 +1,8 @@
-use std::fs::OpenOptions;
+use std::fs::{self, OpenOptions};
 use std::io::Write as IoWrite;
+use std::path;
 
+use anyhow::Result;
 use atty::Stream;
 use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
 use regex::Regex;
@@ -15,18 +17,30 @@ fn get_content_length(headers: &HeaderMap) -> Option<u64> {
 
 // TODO: avoid name conflict unless `continue` flag is specified
 fn get_file_name(response: &reqwest::Response) -> String {
-    let fallback = response.url().path_segments().unwrap().last().unwrap();
-
-    if let Some(value) = response.headers().get(reqwest::header::CONTENT_DISPOSITION) {
-        let re = Regex::new("filename=\"(.*)\"").unwrap();
-        if let Some(caps) = re.captures(value.to_str().unwrap()) {
-            caps[1].to_string()
-        } else {
-            fallback.to_string()
-        }
-    } else {
-        fallback.to_string()
+    lazy_static::lazy_static! {
+        static ref RE: Regex = Regex::new("filename=\"([^\"]*)\"").unwrap();
     }
+
+    response
+        .headers()
+        .get(reqwest::header::CONTENT_DISPOSITION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| RE.captures(value))
+        .and_then(|caps| {
+            caps[1]
+                .split(path::is_separator)
+                .last()
+                .map(ToString::to_string)
+        })
+        .or_else(|| {
+            response
+                .url()
+                .path_segments()
+                .and_then(|segments| segments.last().map(ToString::to_string))
+        })
+        .map(|name| name.trim().trim_start_matches('.').to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| String::from("index.html"))
 }
 
 pub fn get_file_size(path: &Option<String>) -> Option<u64> {
@@ -36,12 +50,32 @@ pub fn get_file_size(path: &Option<String>) -> Option<u64> {
     }
 }
 
+fn exists(file_name: &str) -> bool {
+    fs::metadata(&file_name).is_ok()
+}
+
+/// Find a file name that doesn't exist yet.
+fn generate_file_name(mut file_name: String) -> String {
+    if !exists(&file_name) {
+        return file_name;
+    }
+    file_name.push('-');
+    let mut suffix: u32 = 1;
+    loop {
+        let candidate = file_name.clone() + &suffix.to_string();
+        if !exists(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
 pub async fn download_file(
     mut response: reqwest::Response,
     file_name: Option<String>,
     resume: bool,
     quiet: bool,
-) {
+) -> Result<()> {
     let (mut buffer, dest_name): (Box<dyn IoWrite>, String) = match file_name {
         Some(file_name) => (
             Box::new(
@@ -49,21 +83,20 @@ pub async fn download_file(
                     .write(true)
                     .create(true)
                     .append(resume)
-                    .open(&file_name)
-                    .unwrap(),
+                    .open(&file_name)?,
             ),
             file_name,
         ),
         None if atty::is(Stream::Stdout) => {
             let file_name = get_file_name(&response);
+            let file_name = generate_file_name(file_name);
             (
                 Box::new(
                     OpenOptions::new()
                         .write(true)
                         .create(true)
                         .append(resume)
-                        .open(&file_name)
-                        .unwrap(),
+                        .open(&file_name)?,
                 ),
                 file_name,
             )
@@ -102,8 +135,8 @@ pub async fn download_file(
     };
 
     let mut downloaded = 0;
-    while let Some(chunk) = response.chunk().await.unwrap() {
-        buffer.write_all(&chunk).unwrap();
+    while let Some(chunk) = response.chunk().await? {
+        buffer.write_all(&chunk)?;
         downloaded += chunk.len() as u64;
         if let Some(pb) = &pb {
             pb.set_position(downloaded);
@@ -113,4 +146,6 @@ pub async fn download_file(
     if let Some(pb) = &pb {
         pb.finish_with_message("Done");
     }
+
+    Ok(())
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -55,14 +55,13 @@ fn exists(file_name: &str) -> bool {
 }
 
 /// Find a file name that doesn't exist yet.
-fn generate_file_name(mut file_name: String) -> String {
+fn generate_file_name(file_name: String) -> String {
     if !exists(&file_name) {
         return file_name;
     }
-    file_name.push('-');
     let mut suffix: u32 = 1;
     loop {
-        let candidate = file_name.clone() + &suffix.to_string();
+        let candidate = format!("{}-{}", file_name, suffix);
         if !exists(&candidate) {
             return candidate;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod request_items;
 mod url;
 mod utils;
 
+use anyhow::{anyhow, Result};
 use auth::Auth;
 use buffer::Buffer;
 use cli::{AuthType, Cli, Method, Pretty, Print, RequestItem, Theme};
@@ -37,36 +38,38 @@ fn get_user_agent() -> &'static str {
 }
 
 #[tokio::main]
-async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     let args = Cli::from_args();
 
     let request_items = RequestItems::new(args.request_items);
     let query = request_items.query();
-    let (headers, headers_to_unset) = request_items.headers();
+    let (headers, headers_to_unset) = request_items.headers()?;
+    #[allow(clippy::eval_order_dependence)]
     let body = match (
         request_items.body(args.form, args.multipart).await?,
-        body_from_stdin(args.ignore_stdin),
+        // TODO: can we give an error before reading all of stdin?
+        body_from_stdin(args.ignore_stdin).await?,
     ) {
         (Some(_), Some(_)) => {
-            return Err(
-                "Request body (from stdin) and Request data (key=value) cannot be mixed".into(),
-            )
+            return Err(anyhow!(
+                "Request body (from stdin) and Request data (key=value) cannot be mixed"
+            ))
         }
         (Some(body), None) | (None, Some(body)) => Some(body),
         (None, None) => None,
     };
 
     let (method, url) = args.method_url;
-    let url = Url::new(url, args.default_scheme);
-    let host = url.host().unwrap();
-    let method = method.unwrap_or(Method::from(&body)).into();
-    let auth = Auth::new(args.auth, args.auth_type, &host);
+    let url = Url::new(url, args.default_scheme)?;
+    let host = url.host().ok_or_else(|| anyhow!("Missing hostname"))?;
+    let method = method.unwrap_or_else(|| Method::from(&body)).into();
+    let auth = Auth::new(args.auth, args.auth_type, &host)?;
     let redirect = match args.follow {
         true => Policy::limited(args.max_redirects.unwrap_or(10)),
         false => Policy::none(),
     };
 
-    let client = Client::builder().redirect(redirect).build().unwrap();
+    let client = Client::builder().redirect(redirect).build()?;
     let request = {
         let mut request_builder = client
             .request(method, url.0)
@@ -114,27 +117,28 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     };
 
     let buffer = Buffer::new(args.download, &args.output, atty::is(Stream::Stdout))?;
-    let print = args
-        .print
-        .unwrap_or(Print::new(args.verbose, args.quiet, args.offline, &buffer));
+    let print = match args.print {
+        Some(print) => print,
+        None => Print::new(args.verbose, args.quiet, args.offline, &buffer),
+    };
     let mut printer = Printer::new(args.pretty, args.theme, args.stream, buffer);
 
     if print.request_headers {
-        printer.print_request_headers(&request);
+        printer.print_request_headers(&request)?;
     }
     if print.request_body {
-        printer.print_request_body(&request);
+        printer.print_request_body(&request)?;
     }
     if !args.offline {
         let response = client.execute(request).await?;
         if print.response_headers {
-            printer.print_response_headers(&response);
+            printer.print_response_headers(&response)?;
         }
         if args.download {
-            let resume = &response.status() == &StatusCode::PARTIAL_CONTENT;
-            download_file(response, args.output, resume, args.quiet).await;
+            let resume = response.status() == StatusCode::PARTIAL_CONTENT;
+            download_file(response, args.output, resume, args.quiet).await?;
         } else if print.response_body {
-            printer.print_response_body(response).await;
+            printer.print_response_body(response).await?;
         }
     }
     Ok(())

--- a/src/request_items.rs
+++ b/src/request_items.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::multipart;
 
@@ -19,50 +20,43 @@ impl RequestItems {
     }
 
     fn form_file_count(&self) -> usize {
-        let mut count = 0;
-        for item in &self.0 {
-            match item {
-                RequestItem::FormFile(_, _, _) => count += 1,
-                _ => {}
-            }
-        }
-        count
+        self.0
+            .iter()
+            .filter(|item| matches!(item, RequestItem::FormFile(..)))
+            .count()
     }
 
-    pub fn headers(&self) -> (HeaderMap<HeaderValue>, Vec<HeaderName>) {
+    pub fn headers(&self) -> Result<(HeaderMap<HeaderValue>, Vec<HeaderName>)> {
         let mut headers = HeaderMap::new();
         let mut headers_to_unset = vec![];
         for item in &self.0 {
             match item {
                 RequestItem::HttpHeader(key, value) => {
-                    let key = HeaderName::from_bytes(&key.as_bytes()).unwrap();
-                    let value = HeaderValue::from_str(&value).unwrap();
+                    let key = HeaderName::from_bytes(&key.as_bytes())?;
+                    let value = HeaderValue::from_str(&value)?;
                     headers.insert(key, value);
                 }
                 RequestItem::HttpHeaderToUnset(key) => {
-                    let key = HeaderName::from_bytes(&key.as_bytes()).unwrap();
+                    let key = HeaderName::from_bytes(&key.as_bytes())?;
                     headers_to_unset.push(key);
                 }
                 _ => {}
             }
         }
-        (headers, headers_to_unset)
+        Ok((headers, headers_to_unset))
     }
 
     pub fn query(&self) -> Vec<(&String, &String)> {
         let mut query = vec![];
         for item in &self.0 {
-            match item {
-                RequestItem::UrlParam(key, value) => {
-                    query.push((key, value));
-                }
-                _ => {}
+            if let RequestItem::UrlParam(key, value) = item {
+                query.push((key, value));
             }
         }
         query
     }
 
-    fn body_as_json(&self) -> Result<Option<Body>, &str> {
+    fn body_as_json(&self) -> Result<Option<Body>> {
         let mut body = serde_json::Map::new();
         for item in &self.0 {
             match item.clone() {
@@ -73,9 +67,9 @@ impl RequestItems {
                     body.insert(key, serde_json::Value::String(value));
                 }
                 RequestItem::FormFile(_, _, _) => {
-                    return Err(
-                        "Sending Files is not supported when the request body is in JSON format",
-                    );
+                    return Err(anyhow!(
+                        "Sending Files is not supported when the request body is in JSON format"
+                    ));
                 }
                 _ => {}
             }
@@ -87,12 +81,12 @@ impl RequestItems {
         }
     }
 
-    fn body_as_form(&self) -> Result<Option<Body>, &str> {
+    fn body_as_form(&self) -> Result<Option<Body>> {
         let mut text_fields = Vec::<(String, String)>::new();
         for item in &self.0 {
             match item.clone() {
                 RequestItem::JSONField(_, _) => {
-                    return Err("JSON values are not supported in Form fields");
+                    return Err(anyhow!("JSON values are not supported in Form fields"));
                 }
                 RequestItem::DataField(key, value) => text_fields.push((key, value)),
                 _ => {}
@@ -101,20 +95,20 @@ impl RequestItems {
         Ok(Some(Body::Form(text_fields)))
     }
 
-    async fn body_as_multipart(&self) -> Result<Option<Body>, &str> {
+    async fn body_as_multipart(&self) -> Result<Option<Body>> {
         let mut form = multipart::Form::new();
         for item in &self.0 {
             match item.clone() {
                 RequestItem::JSONField(_, _) => {
-                    return Err("JSON values are not supported in multipart fields");
+                    return Err(anyhow!("JSON values are not supported in multipart fields"));
                 }
                 RequestItem::DataField(key, value) => {
                     form = form.text(key, value);
                 }
                 RequestItem::FormFile(key, value, file_type) => {
-                    let mut part = file_to_part(&value).await.unwrap();
+                    let mut part = file_to_part(&value).await?;
                     if let Some(file_type) = file_type {
-                        part = part.mime_str(&file_type).unwrap();
+                        part = part.mime_str(&file_type)?;
                     }
                     form = form.part(key, part);
                 }
@@ -124,7 +118,7 @@ impl RequestItems {
         Ok(Some(Body::Multipart(form)))
     }
 
-    pub async fn body(&self, form: bool, multipart: bool) -> Result<Option<Body>, &str> {
+    pub async fn body(&self, form: bool, multipart: bool) -> Result<Option<Body>> {
         match (form, multipart) {
             (_, true) => self.body_as_multipart().await,
             (true, _) if self.form_file_count() > 0 => self.body_as_multipart().await,

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,20 +1,24 @@
+use anyhow::Result;
 use regex::Regex;
 
 pub struct Url(pub reqwest::Url);
 
 impl Url {
-    pub fn new(url: String, default_scheme: Option<String>) -> Url {
-        let default_scheme = default_scheme.unwrap_or("http://".to_string());
-        let re = Regex::new("[a-zA-Z]://.+").unwrap();
-        if url.starts_with(':') {
-            let url = format!("{}{}{}", default_scheme, "localhost", url);
-            Url(reqwest::Url::parse(&url).unwrap())
-        } else if !re.is_match(&url) {
-            let url = format!("{}{}", default_scheme, url);
-            Url(reqwest::Url::parse(&url).unwrap())
-        } else {
-            Url(reqwest::Url::parse(&url).unwrap())
+    pub fn new(url: String, default_scheme: Option<String>) -> Result<Url> {
+        lazy_static::lazy_static! {
+            static ref RE: Regex = Regex::new("[a-zA-Z]://.+").unwrap();
         }
+
+        let default_scheme = default_scheme.as_deref().unwrap_or("http://");
+        Ok(if url.starts_with(':') {
+            let url = format!("{}{}{}", default_scheme, "localhost", url);
+            Url(reqwest::Url::parse(&url)?)
+        } else if !RE.is_match(&url) {
+            let url = format!("{}{}", default_scheme, url);
+            Url(reqwest::Url::parse(&url)?)
+        } else {
+            Url(reqwest::Url::parse(&url)?)
+        })
     }
 
     pub fn host(&self) -> Option<String> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -109,7 +109,6 @@ pub fn colorize<'a>(
     };
 
     for line in LinesWithEndings::from(text) {
-        let mut s: String = String::new();
         let highlights = h.highlight(line, &PS);
         for (style, component) in highlights {
             let mut color = Style {
@@ -119,9 +118,8 @@ pub fn colorize<'a>(
             if style.font_style.contains(FontStyle::UNDERLINE) {
                 color = color.underline();
             }
-            s.push_str(&color.paint(component));
+            write!(out, "{}", color.paint(component))?;
         }
-        write!(out, "{}", s)?;
     }
     write!(out, "\x1b[0m")?;
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,9 @@
-use std::fmt::Write;
-use std::io::{self, Read};
+use std::io::{self, Write};
 use std::path::Path;
 
 use ansi_term::Color::{self, Fixed, RGB};
 use ansi_term::{self, Style};
+use anyhow::{anyhow, Result};
 use atty::Stream;
 use reqwest::{
     header::{HeaderMap, CONTENT_TYPE},
@@ -14,7 +14,7 @@ use syntect::easy::HighlightLines;
 use syntect::highlighting::{FontStyle, ThemeSet};
 use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
-use tokio::fs::File;
+use tokio::{fs::File, io::AsyncReadExt};
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 use crate::Body;
@@ -68,27 +68,28 @@ pub async fn file_to_part(path: impl AsRef<Path>) -> io::Result<multipart::Part>
     Ok(part)
 }
 
-pub fn body_from_stdin(ignore_stdin: bool) -> Option<Body> {
+pub async fn body_from_stdin(ignore_stdin: bool) -> Result<Option<Body>> {
     if atty::is(Stream::Stdin) || ignore_stdin {
-        None
+        Ok(None)
     } else {
         let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer).unwrap();
-        Some(Body::Raw(buffer))
+        tokio::io::stdin().read_to_string(&mut buffer).await?;
+        Ok(Some(Body::Raw(buffer)))
     }
 }
 
-pub fn indent_json(text: &str) -> String {
+pub fn indent_json(text: &str) -> Result<String> {
     let mut fmt = jsonxf::Formatter::pretty_printer();
     fmt.indent = String::from("    ");
-    fmt.format(text).unwrap()
+    fmt.format(text).map_err(|msg| anyhow!(msg))
 }
 
 pub fn colorize<'a>(
     text: &'a str,
     syntax: &str,
     theme: &Theme,
-) -> impl Iterator<Item = String> + 'a {
+    mut out: impl Write,
+) -> io::Result<()> {
     lazy_static::lazy_static! {
         static ref TS: ThemeSet = from_binary(include_bytes!(concat!(
             env!("OUT_DIR"),
@@ -99,29 +100,31 @@ pub fn colorize<'a>(
             "/syntax.packdump"
         )));
     }
-    let syntax = PS.find_syntax_by_extension(syntax).unwrap();
+    let syntax = PS
+        .find_syntax_by_extension(syntax)
+        .expect("syntax not found");
     let mut h = match theme {
         Theme::Auto => HighlightLines::new(syntax, &TS.themes["ansi"]),
         Theme::Solarized => HighlightLines::new(syntax, &TS.themes["solarized"]),
     };
 
-    LinesWithEndings::from(text)
-        .map(move |line| {
-            let mut s: String = String::new();
-            let highlights = h.highlight(line, &PS);
-            for (style, component) in highlights {
-                let mut color = Style {
-                    foreground: to_ansi_color(style.foreground),
-                    ..Style::default()
-                };
-                if style.font_style.contains(FontStyle::UNDERLINE) {
-                    color = color.underline();
-                }
-                write!(s, "{}", &color.paint(component)).unwrap();
+    for line in LinesWithEndings::from(text) {
+        let mut s: String = String::new();
+        let highlights = h.highlight(line, &PS);
+        for (style, component) in highlights {
+            let mut color = Style {
+                foreground: to_ansi_color(style.foreground),
+                ..Style::default()
+            };
+            if style.font_style.contains(FontStyle::UNDERLINE) {
+                color = color.underline();
             }
-            s
-        })
-        .chain(std::iter::once("\x1b[0m".into()))
+            s.push_str(&color.paint(component));
+        }
+        write!(out, "{}", s)?;
+    }
+    write!(out, "\x1b[0m")?;
+    Ok(())
 }
 
 // https://github.com/sharkdp/bat/blob/3a85fd767bd1f03debd0a60ac5bc08548f95bc9d/src/terminal.rs

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,7 +1,7 @@
 use assert_cmd::prelude::*;
 use indoc::indoc;
-use std::process::Command;
 use predicates::prelude::*;
+use std::process::Command;
 
 fn get_command() -> Command {
     let mut cmd = Command::cargo_bin("ht").expect("binary should be present");
@@ -95,8 +95,9 @@ fn basic_options() -> Result<(), Box<dyn std::error::Error>> {
         .arg("httpbin.org/json");
 
     // Verify that the response is ok and contains an 'allow' header.
-    cmd.assert().stdout(predicate::str::contains("HTTP/1.1 200 OK"));
+    cmd.assert()
+        .stdout(predicate::str::contains("HTTP/1.1 200 OK"));
     cmd.assert().stdout(predicate::str::contains("allow:"));
-    
+
     Ok(())
 }


### PR DESCRIPTION
In theory, all panics after this should be bugs instead of normal error conditions.

The error reporting may still need finetuning. For example, if the hostname doesn't resolve you get a redundant traceback:

```
Error: error sending request for url (http://bad-hostname/): error trying to connect: dns error: failed to lookup address information: Name or service not known

Caused by:
    0: error trying to connect: dns error: failed to lookup address information: Name or service not known
    1: dns error: failed to lookup address information: Name or service not known
    2: failed to lookup address information: Name or service not known
```

This commit also fixes all of the remaining Clippy warnings.

Resolves #14 (?)