### PR TITLE
Add -b body param from httpie, some clippy fixes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,6 +53,10 @@ pub struct Cli {
     #[structopt(short = "d", long)]
     pub download: bool,
 
+    /// Print only the response body, Shortcut for --print=b.
+    #[structopt(short = "b", long)]
+    pub body: bool,
+
     /// Resume an interrupted download.
     #[structopt(short = "c", long = "continue")]
     pub resume: bool,
@@ -221,7 +225,7 @@ pub struct Print {
 }
 
 impl Print {
-    pub fn new(verbose: bool, quiet: bool, offline: bool, buffer: &Buffer) -> Self {
+    pub fn new(verbose: bool, body: bool, quiet: bool, offline: bool, buffer: &Buffer) -> Self {
         if verbose {
             Print {
                 request_headers: true,
@@ -243,7 +247,7 @@ impl Print {
                 response_headers: false,
                 response_body: false,
             }
-        } else if matches!(buffer, Buffer::Redirect | Buffer::File(_)) {
+        } else if body || matches!(buffer, Buffer::Redirect | Buffer::File(_)) {
             Print {
                 request_headers: false,
                 request_body: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,9 +114,13 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     };
 
     let buffer = Buffer::new(args.download, &args.output, atty::is(Stream::Stdout))?;
-    let print = args
-        .print
-        .unwrap_or(Print::new(args.verbose, args.quiet, args.offline, &buffer));
+    let print = args.print.unwrap_or(Print::new(
+        args.verbose,
+        args.body,
+        args.quiet,
+        args.offline,
+        &buffer,
+    ));
     let mut printer = Printer::new(args.pretty, args.theme, args.stream, buffer);
 
     if print.request_headers {


### PR DESCRIPTION
Hey @ducaale !

Wanting to move from httpie to ht I realized I had a lot of cmd aliases reliant on `http -b`.
When I saw there was no support for -b here I thought I could maybe chip in and add it myself.

So this is this PR, also I tried to fix some clippy warnings on the way.

Let me know what you think! 
Thanks!