### PR TITLE
Update README.md about installation for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ Yet another [HTTPie](https://httpie.io/) clone in Rust.
 brew install ht-rust
 ```
 
-### On Arch Linux via AUR
-[ht-bin AUR package](https://aur.archlinux.org/packages/ht-bin)
+### On Arch Linux via Pacman
 
 ```
-yay -S ht-bin
+pacman -S ht
 ```
 
 ### From binaries

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ brew install ht-rust
 pacman -S ht
 ```
 
+(`ht` binary will be installed as `ht-rust`)
+
 ### From binaries
 The [release page](https://github.com/ducaale/ht/releases) contains prebuilt binaries for Linux, macOS and Windows.
 


### PR DESCRIPTION
Hey!

`ht` is moved to the [community](https://wiki.archlinux.org/index.php/Official_repositories#community) repository of Arch Linux: https://archlinux.org/packages/community/x86_64/ht/
This pull request basically updates the instructions about installating `ht` via [pacman](https://wiki.archlinux.org/index.php/Pacman). (2433cfd)

One little issue is `ht` is installed as `/usr/bin/ht-rs` since it conflicts with [another package](https://archlinux.org/packages/extra/any/texlive-core/) which installs a binary named "ht" to `/usr/bin/ht`. I'm not sure what else can be done about this but I thought it'd appropriate to make you aware of this situation. Users can easily work this around with a simple `alias ht=ht-rs`.

BR,
orhun.