### PR TITLE
update README with official Arch Linux package installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Yet another [HTTPie](https://httpie.io/) clone in Rust.
 brew install ht-rust
 ```
 
-### On Arch Linux via AUR
-[ht-bin AUR package](https://aur.archlinux.org/packages/ht-bin)
+### On Arch Linux via pacman 
+[ht Arch package](https://archlinux.org/packages/community/x86_64/ht/)
 
 ```
-yay -S ht-bin
+pacman -S ht-bin
 ```
 
 ### From binaries


### PR DESCRIPTION
While updating my packages this morning, I noticed that `ht-bin` was no longer present in the AUR. At first I thought the name might have been changed, but it turns out that it was moved to the official pacman repository! I figured the installation instructions should be updated, and since the changes were small, I threw them in a PR to make it easier for you (although if you'd prefer to make different changes, feel free to close this PR or push directly to this branch!)